### PR TITLE
Add "show all products" logic from PWA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2024-04-11
+### Added
+- Adds compatibility with "show all products" feature.
+
 ## [1.1.0] - 2023-11-21
 ### Added
 - Adds config to add BurgerIcon to the TabBar.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Default Values:
 }
 ```
 
+#### showAllProducts:
+This configuration is used to determine if the show all products function from the PWA will also be activated for the category drawer.
+Default Values:
+```json
+{
+  "showAllProducts": true
+}
+```
+
 ## About Shopgate
 
 Shopgate is the leading mobile commerce platform.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This configuration is used to determine if the show all products function from t
 Default Values:
 ```json
 {
-  "showAllProducts": true
+  "showAllProducts": false
 }
 ```
 

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "id": "@shopgate-project/category-drawer",
   "components": [
     {
@@ -58,6 +58,15 @@
         "label": "Mapping for tag and image srcs",
         "description": "The various tags/properties and src associations for extension. The badge hierarchy for items with multiple trigger tags is determined by array.",
         "type": "json"
+      }
+    },
+    "showAllProducts": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "label": "true/false to show all products",
+        "type": "bool"
       }
     },
     "credentials": {

--- a/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
+++ b/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
@@ -161,7 +161,7 @@ const CategoriesItem = ({
               <I18n.Text string="category.showAllProducts.label" />
             </Link>
           ) :
-          null
+            null
           }
           <CategoriesItemChildren subcategories={subcategories} level={level + 1} />
           <HtmlSanitizer className={styles.drawer}>

--- a/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
+++ b/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
@@ -3,11 +3,15 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import classNames from 'classnames';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
-import { HtmlSanitizer, ChevronIcon } from '@shopgate/engage/components';
+import { HtmlSanitizer, ChevronIcon, Link } from '@shopgate/engage/components';
+import { bin2hex } from '@shopgate/engage/core';
 import CategoriesItemChildren from '../CategoriesItemChildren';
 import Item from '../Item';
 import connect from './connector';
 import { useSideNavigation } from '../../hooks';
+import getConfig from '../../../../helpers/getConfig';
+
+const { showAllProducts } = getConfig();
 
 const { colors } = themeConfig;
 
@@ -61,6 +65,10 @@ const styles = {
     ' a': {
       textDecoration: 'underline',
     },
+  }).toString(),
+  link: css({
+    padding: '12px 16px',
+    fontWeight: '400',
   }).toString(),
 };
 
@@ -148,6 +156,13 @@ const CategoriesItem = ({
     >
       { !maxNestingReached && hasSubcategories && subcategories && (
         <div className={classes}>
+          { showAllProducts ? (
+            <Link href={`/category/${bin2hex(categoryId)}/all`} className={styles.link}>
+              Alle Produkte anzeigen
+            </Link>
+          ) :
+          null
+          }
           <CategoriesItemChildren subcategories={subcategories} level={level + 1} />
           <HtmlSanitizer className={styles.drawer}>
             {content}

--- a/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
+++ b/frontend/components/NavDrawerCategoriesTree/components/CategoriesItem/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import classNames from 'classnames';
 import { themeConfig } from '@shopgate/pwa-common/helpers/config';
-import { HtmlSanitizer, ChevronIcon, Link } from '@shopgate/engage/components';
+import { HtmlSanitizer, ChevronIcon, Link, I18n } from '@shopgate/engage/components';
 import { bin2hex } from '@shopgate/engage/core';
 import CategoriesItemChildren from '../CategoriesItemChildren';
 import Item from '../Item';
@@ -158,7 +158,7 @@ const CategoriesItem = ({
         <div className={classes}>
           { showAllProducts ? (
             <Link href={`/category/${bin2hex(categoryId)}/all`} className={styles.link}>
-              Alle Produkte anzeigen
+              <I18n.Text string="category.showAllProducts.label" />
             </Link>
           ) :
           null

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
-    "eslint": "^4.19.1",
+    "eslint": "^6.8.0",
     "glamor": "^2.20.40",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",


### PR DESCRIPTION
Adds the "show all products" logic from PWA to the category drawer.

The "show all products" function needs to be activated in the theme config and the extension config `showAllProducts` needs to be set to `true`