### PR TITLE
Fix logo category drawer overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,35 @@
 # Changelog
 
-## [1.6.0] - 2025-08-01
+## 1.6.1 - 2025-08-21
+### Fixed
+- Fixed logo overlapping category drawer icon when category drawer extension is combined with page switcher
+
+## 1.6.0 - 2025-08-01
 ### Added
 - fetching categories from Catalog service if set up
 
-## [1.5.0] - 2025-07-03
+## 1.5.0 - 2025-07-03
 ### Added
 - Supports position of burger icon in app bar (only on home page)
 
-## [1.4.0] - 2025-04-10
+## 1.4.0 - 2025-04-10
 ### Fixed
 - Fixed accessibility for screen readers
 
-## [1.3.0] - 2025-04-07
+## 1.3.0 - 2025-04-07
 ### Added
 - Improved accessibility for screen readers
 
-## [1.2.0] - 2024-04-11
+## 1.2.0 - 2024-04-11
 ### Added
 - Adds compatibility with "show all products" feature.
 
-## [1.1.0] - 2023-11-21
+## 1.1.0 - 2023-11-21
 ### Added
 - Adds config to add BurgerIcon to the TabBar.
 - Adds configuration to add content to the Category Drawer.
 - Adds compatibility with extension [@shopgate-project/page-switcher](https://github.com/shopgate-professional-services/ext-page-switcher)
 
-## [1.0.0] - 2022-07-27
+## 1.0.0 - 2022-07-27
 ### Added
 - Adds BurgerIcon to open a Category Drawer.

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "id": "@shopgate-project/category-drawer",
   "components": [
     {

--- a/frontend/portals/AppBarBurgerIcon/index.jsx
+++ b/frontend/portals/AppBarBurgerIcon/index.jsx
@@ -16,9 +16,6 @@ const styles = {
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
-    // position: 'absolute',
-    // top: '50%',
-    // transform: 'translateY(-50%)',
   }).toString(),
 };
 
@@ -33,7 +30,7 @@ const mapStateToProps = state => ({
 
 const { showAppBarNavDrawer } = getConfig();
 
-// fix logo overlapping category drawer when both extensions are used in app header
+// fix logo overlapping category drawer in app header
 if (showAppBarNavDrawer) {
   css.global('.engage__logo > img', {
     margin: '0',

--- a/frontend/portals/AppBarBurgerIcon/index.jsx
+++ b/frontend/portals/AppBarBurgerIcon/index.jsx
@@ -16,9 +16,9 @@ const styles = {
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
-    position: 'absolute',
-    top: '50%',
-    transform: 'translateY(-50%)',
+    // position: 'absolute',
+    // top: '50%',
+    // transform: 'translateY(-50%)',
   }).toString(),
 };
 
@@ -32,6 +32,13 @@ const mapStateToProps = state => ({
 });
 
 const { showAppBarNavDrawer } = getConfig();
+
+// fix logo overlapping category drawer when both extensions are used in app header
+if (showAppBarNavDrawer) {
+  css.global('.engage__logo > img', {
+    margin: '0',
+  });
+}
 
 /**
  * AppBarBurgerIcon


### PR DESCRIPTION
We are fixing the following issue: When using the category drawer in combination with the page switcher extension in the setting "showAppBarNavDrawer", the category drawer icon overlaps the logo in the app header. 