### PR TITLE
Add support for the receiveCategories action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0 - 2026-03-03
+### Added
+- Extension will use the `receiveCategories` action when available to add categories into Redux
+
 ## 1.6.2 - 2026-01-21
 ### Fixed
 - Fixed color and alignment of browse icon

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.2",
+  "version": "1.7.0-beta.1",
   "id": "@shopgate-project/category-drawer",
   "components": [
     {

--- a/frontend/actions/index.js
+++ b/frontend/actions/index.js
@@ -10,6 +10,18 @@ import {
   requestCategoryTree,
 } from '../action-creators';
 
+let receiveCategories;
+
+try {
+  // Not all PWA versions support the receiveCategories action creator, so we use require here to
+  // prevent errors in unsupported versions. Fallback logic is used in case the action creator is
+  // not available, which adds the fetched categories to our redux store to benefit from it.
+  // eslint-disable-next-line global-require
+  receiveCategories = require('@shopgate/pwa-common-commerce/category/action-creators/receiveCategories').default;
+} catch (e) {
+  receiveCategories = null;
+}
+
 /**
  * @param {boolean} [forceFetch=false] forces fetch
  * @return {Function}
@@ -29,14 +41,28 @@ export const fetchCategoryTree = (forceFetch = false) => (dispatch, getState) =>
     .then(({ categoryTree }) => {
       dispatch(receiveCategoryTree(categoryTree));
 
-      // Add the fetched categories to our redux to benefit from it
-      categoryTree.forEach((category) => {
-        dispatch(receiveCategory(category.id, category, (category.children || [])));
-
-        category.children.forEach((categoryLevel2) => {
-          dispatch(receiveCategoryChildren(categoryLevel2.id, categoryLevel2.children));
+      if (receiveCategories) {
+        const categories = [];
+        categoryTree.forEach((category) => {
+          categories.push(category);
+          if (category.children) {
+            category.children.forEach((child) => {
+              categories.push(child);
+            });
+          }
         });
-      });
+
+        dispatch(receiveCategories(categories));
+      } else {
+        // Add the fetched categories to our redux to benefit from it
+        categoryTree.forEach((category) => {
+          dispatch(receiveCategory(category.id, category, (category.children || [])));
+
+          category.children.forEach((categoryLevel2) => {
+            dispatch(receiveCategoryChildren(categoryLevel2.id, categoryLevel2.children));
+          });
+        });
+      }
     })
     .catch((error) => {
       logger.error(error);


### PR DESCRIPTION
The extension will now use the `receiveCategories` action when available to move categories into the categories store. That will reduce the amount of re-renders when the category tree is received.